### PR TITLE
Async wip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ edition = '2018'
 
 
 [dependencies]
+futures = "0.1.25"
 libc = "~0.2"
 libnfs-sys = "~0.2"
+log = "~0.4"
+mio = "~0.6"
 nix = "~0.11"
+tokio = "~0.1"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,10 +6,19 @@ use nix::{fcntl::OFlag, sys::stat::Mode};
 
 fn main() -> Result<()> {
     let mut nfs = Nfs::new()?;
-    nfs.set_uid(1000)?;
-    nfs.set_gid(1000)?;
+    //nfs.set_uid(0)?;
+    //nfs.set_gid(0)?;
     nfs.set_debug(9)?;
-    nfs.mount("0.0.0.0", "/srv/nfs")?;
+    println!("mounting");
+    nfs.mount("192.168.122.78", "/var/nfs")?;
+    nfs.stat64_async(&Path::new("foo"), |result|{
+        println!("async stat result: {:?}", result);
+
+        // Pass it on
+        result
+    })?;
+    nfs.run_async()?;
+    /*
 
     let dir = nfs.opendir(&Path::new("/"))?;
     for f in dir {
@@ -29,5 +38,6 @@ fn main() -> Result<()> {
     let file = nfs.open(&Path::new("/rust"), OFlag::O_RDONLY)?;
     let buff = file.read(1024)?;
     println!("read file: {}", String::from_utf8_lossy(&buff));
+    */
     Ok(())
 }


### PR DESCRIPTION
@mzhong1 so I was playing around with the async functionality of libnfs and I'm wondering if this would be ok to use.  This would require the library user to setup a function for nfs to call you later with.  It would look like:
```
#[no_mangle]
pub unsafe extern "C" fn nfs_callback(result: i32, 
    *mut nfs_context, 
    *mut c_void, *mut c_void) {
    // do things
}
```
Not sure if that'll be ok or annoying to use.  
@jsgf you mentioned you did this with oneshot.  Could you provide an example maybe?  I'm scratching my head about how that would work.  